### PR TITLE
Major updates to the threading model

### DIFF
--- a/FRC-Extension/Buttons/AboutButton.cs
+++ b/FRC-Extension/Buttons/AboutButton.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace RobotDotNet.FRC_Extension.Buttons
 {
     public class AboutButton : ButtonBase
-    { 
+    {
 
         public AboutButton(Frc_ExtensionPackage package) : base(package, false, GuidList.guidFRC_ExtensionCmdSet, (int)PkgCmdIDList.cmdidAboutButton)
         {
@@ -16,7 +17,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
             //TODO: Get version
 
             // Show a Message Box to prove we were here
-            IVsUIShell uiShell = (IVsUIShell)Package.PublicGetService(typeof(SVsUIShell));
+            IVsUIShell uiShell = Package.PublicGetService<IVsUIShell, SVsUIShell>();
             Guid clsid = Guid.Empty;
             int result;
             Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(uiShell.ShowMessageBox(
@@ -31,6 +32,11 @@ namespace RobotDotNet.FRC_Extension.Buttons
                        OLEMSGICON.OLEMSGICON_INFO,
                        0,        // false
                        out result));
+        }
+
+        protected override Task ButtonCallbackAsync(object sender, EventArgs e)
+        {
+            return Task.FromResult(false);
         }
     }
 }

--- a/FRC-Extension/Buttons/ButtonBase.cs
+++ b/FRC-Extension/Buttons/ButtonBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Design;
 using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
 
 namespace RobotDotNet.FRC_Extension.Buttons
 {
@@ -14,10 +15,10 @@ namespace RobotDotNet.FRC_Extension.Buttons
 
         protected ButtonBase(Frc_ExtensionPackage package, bool buttonNeedsQuery, Guid commandSetGuid, int pkgCmdIdOfButton)
         {
-            Output =OutputWriter.Instance;
+            Output = OutputWriter.Instance;
             Package = package;
 
-            OleMenuCommandService mcs = Package.PublicGetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            var mcs = Package.PublicGetService<OleMenuCommandService, IMenuCommandService>();
             if (mcs != null)
             {
                 CommandID commandId = new CommandID(commandSetGuid, pkgCmdIdOfButton);
@@ -30,12 +31,17 @@ namespace RobotDotNet.FRC_Extension.Buttons
             }
         }
 
-        public abstract void ButtonCallback(object sender, EventArgs e);
+#pragma warning disable IDE1006 // Naming Styles
+        public virtual async void ButtonCallback(object sender, EventArgs e)
+#pragma warning restore IDE1006 // Naming Styles
+        {
+            await ButtonCallbackAsync(sender, e).ConfigureAwait(false);
+        }
+
+        protected abstract Task ButtonCallbackAsync(object sender, EventArgs e);
 
         public virtual void QueryCallback(object sender, EventArgs e)
         {
-            
         }
-
     }
 }

--- a/FRC-Extension/Buttons/DeployDebugButton.cs
+++ b/FRC-Extension/Buttons/DeployDebugButton.cs
@@ -26,8 +26,9 @@ namespace RobotDotNet.FRC_Extension.Buttons
             DeployCommands.Add(OleMenuItem);
         }
 
-        private void DisableAllButtons()
+        private async Task DisableAllButtonsAsync()
         {
+            await ThreadHelperExtensions.SwitchToUiThread();
             foreach (var oleMenuCommand in DeployCommands)
             {
                 oleMenuCommand.Enabled = false;
@@ -35,8 +36,9 @@ namespace RobotDotNet.FRC_Extension.Buttons
             Deploying = true;
         }
 
-        private void EnableAllButtons()
+        private async Task EnableAllButtonsAsync()
         {
+            await ThreadHelperExtensions.SwitchToUiThread();
             foreach (var oleMenuCommand in DeployCommands)
             {
                 oleMenuCommand.Enabled = true;
@@ -63,25 +65,25 @@ namespace RobotDotNet.FRC_Extension.Buttons
                     if (teamNumber == null) return;
 
                     //Disable the deploy buttons
+                    await DisableAllButtonsAsync().ConfigureAwait(false);
                     await ThreadHelperExtensions.SwitchToUiThread();
-                    DisableAllButtons();
                     DeployManager m = new DeployManager(Package.PublicGetService<DTE>());
-                    bool success = await m.DeployCodeAsync(teamNumber, DebugButton, m_robotProject).ConfigureAwait(true);
-                    EnableAllButtons();
+                    bool success = await m.DeployCodeAsync(teamNumber, DebugButton, m_robotProject).ConfigureAwait(false);
+                    await EnableAllButtonsAsync().ConfigureAwait(false);
                     Output.ProgressBarLabel = success ? "Robot Code Deploy Successful" : "Robot Code Deploy Failed";
                 }
                 catch (SshConnectionException)
                 {
                     await Output.WriteLineAsync("Connection to RoboRIO lost. Deploy aborted.").ConfigureAwait(false);
                     await ThreadHelperExtensions.SwitchToUiThread();
-                    EnableAllButtons();
+                    await EnableAllButtonsAsync().ConfigureAwait(true);
                     Output.ProgressBarLabel = "Robot Code Deploy Failed";
                 }
                 catch (Exception ex)
                 {
                     await Output.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
                     await ThreadHelperExtensions.SwitchToUiThread();
-                    EnableAllButtons();
+                    await EnableAllButtonsAsync().ConfigureAwait(true);
                     Output.ProgressBarLabel = "Robot Code Deploy Failed";
                 }
 

--- a/FRC-Extension/Buttons/DeployDebugButton.cs
+++ b/FRC-Extension/Buttons/DeployDebugButton.cs
@@ -67,8 +67,12 @@ namespace RobotDotNet.FRC_Extension.Buttons
                     //Disable the deploy buttons
                     await DisableAllButtonsAsync().ConfigureAwait(false);
                     await ThreadHelperExtensions.SwitchToUiThread();
-                    DeployManager m = new DeployManager(Package.PublicGetService<DTE>());
-                    bool success = await m.DeployCodeAsync(teamNumber, DebugButton, m_robotProject).ConfigureAwait(false);
+                    bool success = false;
+                    using (DeployManager m = new DeployManager(Package.PublicGetService<DTE>()))
+                    {
+                        success =
+                            await m.DeployCodeAsync(teamNumber, DebugButton, m_robotProject).ConfigureAwait(false);
+                    }
                     await EnableAllButtonsAsync().ConfigureAwait(false);
                     Output.ProgressBarLabel = success ? "Robot Code Deploy Successful" : "Robot Code Deploy Failed";
                 }

--- a/FRC-Extension/Buttons/InstallMonoButton.cs
+++ b/FRC-Extension/Buttons/InstallMonoButton.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -16,7 +15,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
         private bool m_installing;
 
         public InstallMonoButton(Frc_ExtensionPackage package, MonoFile monoFile)
-            : base(package, false, GuidList.guidFRC_ExtensionCmdSet, (int) PkgCmdIDList.cmdidInstallMono)
+            : base(package, false, GuidList.guidFRC_ExtensionCmdSet, (int)PkgCmdIDList.cmdidInstallMono)
         {
             m_monoFile = monoFile;
         }
@@ -26,8 +25,9 @@ namespace RobotDotNet.FRC_Extension.Buttons
             return OleMenuItem;
         }
 
-        public override async void ButtonCallback(object sender, EventArgs e)
+        protected override async Task ButtonCallbackAsync(object sender, EventArgs e)
         {
+            await ThreadHelperExtensions.SwitchToUiThread();
             var menuCommand = sender as OleMenuCommand;
             if (menuCommand == null)
             {
@@ -45,9 +45,10 @@ namespace RobotDotNet.FRC_Extension.Buttons
                     if (properFileExists)
                     {
                         //We can deploy
+                        await ThreadHelperExtensions.SwitchToUiThread();
                         m_installing = true;
                         menuCommand.Visible = false;
-                        await DeployMono(menuCommand);
+                        await DeployMonoAsync(menuCommand).ConfigureAwait(true);
                         m_installing = false;
                         menuCommand.Visible = true;
                     }
@@ -65,7 +66,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
                             if (properFileExists)
                             {
                                 //We can deploy
-                                await DeployMono(menuCommand);
+                                await DeployMonoAsync(menuCommand).ConfigureAwait(false);
                             }
                             else
                             {
@@ -81,39 +82,40 @@ namespace RobotDotNet.FRC_Extension.Buttons
                 }
                 catch (SshConnectionException)
                 {
-                    Output.WriteLine("Connection to RoboRIO lost. Install aborted.");
+                    await Output.WriteLineAsync("Connection to RoboRIO lost. Install aborted.").ConfigureAwait(false);
+                    await ThreadHelperExtensions.SwitchToUiThread();
                     m_installing = false;
                     menuCommand.Visible = true;
                     Output.ProgressBarLabel = "Mono Install Failed";
                 }
                 catch (Exception ex)
                 {
-                    Output.WriteLine(ex.ToString());
+                    await Output.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
+                    await ThreadHelperExtensions.SwitchToUiThread();
                     m_installing = false;
                     menuCommand.Visible = true;
                     Output.ProgressBarLabel = "Mono Install Failed";
                 }
             }
         }
-        internal async Task DeployMono(OleMenuCommand menuCommand)
+        internal async Task DeployMonoAsync(OleMenuCommand menuCommand)
         {
             try
             {
 
-                string teamNumber = Package.GetTeamNumber();
+                string teamNumber = await Package.GetTeamNumberAsync().ConfigureAwait(false);
 
                 if (teamNumber == null) return;
 
-
-
                 //Disable Install Button
+                await ThreadHelperExtensions.SwitchToUiThread();
                 m_installing = true;
                 menuCommand.Visible = false;
 
-                DeployManager m = new DeployManager(Package.PublicGetService(typeof(DTE)) as DTE);
+                DeployManager m = new DeployManager(Package.PublicGetService<DTE>());
                 MonoDeploy deploy = new MonoDeploy(teamNumber, m, m_monoFile);
 
-                await deploy.DeployMono();
+                await deploy.DeployMonoAsync().ConfigureAwait(true);
 
                 m_installing = false;
                 menuCommand.Visible = true;
@@ -121,7 +123,8 @@ namespace RobotDotNet.FRC_Extension.Buttons
             }
             catch (Exception ex)
             {
-                Output.WriteLine(ex.ToString());
+                await Output.WriteLineAsync(ex.ToString()).ConfigureAwait(false);
+                await ThreadHelperExtensions.SwitchToUiThread();
                 m_installing = false;
                 menuCommand.Visible = true;
             }
@@ -130,14 +133,14 @@ namespace RobotDotNet.FRC_Extension.Buttons
         public void DownloadMonoPopup()
         {
             // Show a Message Box to prove we were here
-            IVsUIShell uiShell = (IVsUIShell)Package.PublicGetService(typeof(SVsUIShell));
+            IVsUIShell uiShell = Package.PublicGetService<IVsUIShell, SVsUIShell>();
             Guid clsid = Guid.Empty;
             int result;
             Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(uiShell.ShowMessageBox(
                        0,
                        ref clsid,
                        "Please Download Mono. This can be done by clicking the \nDownload Mono button.",
-                       string.Format(CultureInfo.CurrentCulture, "", this.ToString()),
+                       string.Empty,
                        string.Empty,
                        0,
                        OLEMSGBUTTON.OLEMSGBUTTON_OK,
@@ -150,14 +153,14 @@ namespace RobotDotNet.FRC_Extension.Buttons
         public void InvalidMonoPopup()
         {
             // Show a Message Box to prove we were here
-            IVsUIShell uiShell = (IVsUIShell)Package.PublicGetService(typeof(SVsUIShell));
+            IVsUIShell uiShell = Package.PublicGetService<IVsUIShell, SVsUIShell>();
             Guid clsid = Guid.Empty;
             int result;
             Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(uiShell.ShowMessageBox(
                        0,
                        ref clsid,
                        "Mono file is Invalid. Please try again.",
-                       string.Format(CultureInfo.CurrentCulture, "", this.ToString()),
+                       string.Empty,
                        string.Empty,
                        0,
                        OLEMSGBUTTON.OLEMSGBUTTON_OK,
@@ -169,7 +172,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
 
         public string LoadMonoPopup()
         {
-            IVsUIShell uiShell = (IVsUIShell)Package.PublicGetService(typeof(SVsUIShell));
+            IVsUIShell uiShell = Package.PublicGetService<IVsUIShell, SVsUIShell>();
             Guid clsid = Guid.Empty;
             int result;
 

--- a/FRC-Extension/Buttons/InstallMonoButton.cs
+++ b/FRC-Extension/Buttons/InstallMonoButton.cs
@@ -112,8 +112,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
                 m_installing = true;
                 menuCommand.Visible = false;
 
-                DeployManager m = new DeployManager(Package.PublicGetService<DTE>());
-                MonoDeploy deploy = new MonoDeploy(teamNumber, m, m_monoFile);
+                MonoDeploy deploy = new MonoDeploy(teamNumber, m_monoFile);
 
                 await deploy.DeployMonoAsync().ConfigureAwait(true);
 

--- a/FRC-Extension/Buttons/NetConsoleButton.cs
+++ b/FRC-Extension/Buttons/NetConsoleButton.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Microsoft.VisualStudio.Shell;
 using RobotDotNet.FRC_Extension.RoboRIOCode;
+using Task = System.Threading.Tasks.Task;
 
 namespace RobotDotNet.FRC_Extension.Buttons
 {
@@ -29,9 +30,9 @@ namespace RobotDotNet.FRC_Extension.Buttons
         /// <summary>
         /// This function is called when the NetConsole button is pressed.
         /// </summary>
-        public override async void ButtonCallback(object sender, EventArgs e)
+        protected override async Task ButtonCallbackAsync(object sender, EventArgs e)
         {
-            await DeployManager.StartNetConsole();
+            await DeployManager.StartNetConsoleAsync().ConfigureAwait(false);
         }
     }
 }

--- a/FRC-Extension/Buttons/SaveMonoButton.cs
+++ b/FRC-Extension/Buttons/SaveMonoButton.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.Shell;
 using RobotDotNet.FRC_Extension.MonoCode;
+using Task = System.Threading.Tasks.Task;
 
 namespace RobotDotNet.FRC_Extension.Buttons
 {
@@ -14,7 +15,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
             m_monoFile = monoFile;
         }
 
-        public override async void ButtonCallback(object sender, EventArgs e)
+        public override void ButtonCallback(object sender, EventArgs e)
         {
             m_monoFile.SaveMonoFile();
         }
@@ -34,8 +35,13 @@ namespace RobotDotNet.FRC_Extension.Buttons
             }
             catch (Exception ex)
             {
-                OutputWriter.Instance.WriteLine(ex.StackTrace);
+                ThreadHelper.JoinableTaskFactory.Run(() => OutputWriter.Instance.WriteLineAsync(ex.StackTrace));
             }
+        }
+
+        protected override Task ButtonCallbackAsync(object sender, EventArgs e)
+        {
+            return Task.FromResult(false);
         }
     }
 }

--- a/FRC-Extension/Buttons/SetMainRobotButton.cs
+++ b/FRC-Extension/Buttons/SetMainRobotButton.cs
@@ -29,7 +29,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
                 {
                     menuCommand.Visible = false;
                     menuCommand.Enabled = false;
-                }               
+                }
             }
         }
 
@@ -87,7 +87,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
                         /*
                         if (reference.SourceProject == null)
                         {
-                            
+
                         }
                         */
                     }
@@ -109,7 +109,6 @@ namespace RobotDotNet.FRC_Extension.Buttons
             }
         }
 
-
         public override void ButtonCallback(object sender, EventArgs e)
         {
             Project project = GetSelectedProject();
@@ -128,7 +127,7 @@ namespace RobotDotNet.FRC_Extension.Buttons
 
         private void ClearAllProjectsInSolution()
         {
-            var dte = Package.PublicGetService(typeof(DTE)) as DTE;
+            var dte = Package.PublicGetService<DTE>();
             var sb = dte?.Solution;
             if (sb == null)
             {
@@ -149,6 +148,11 @@ namespace RobotDotNet.FRC_Extension.Buttons
                 }
                 p.Save();
             }
+        }
+
+        protected override System.Threading.Tasks.Task ButtonCallbackAsync(object sender, EventArgs e)
+        {
+            return System.Threading.Tasks.Task.FromResult(false);
         }
     }
 }

--- a/FRC-Extension/Buttons/SettingsButton.cs
+++ b/FRC-Extension/Buttons/SettingsButton.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using RobotDotNet.FRC_Extension.SettingsPages;
 
 namespace RobotDotNet.FRC_Extension.Buttons
@@ -12,6 +13,11 @@ namespace RobotDotNet.FRC_Extension.Buttons
         public override void ButtonCallback(object sender, EventArgs e)
         {
             Package.ShowOptionPage(typeof(TeamSettingsPage));
+        }
+
+        protected override Task ButtonCallbackAsync(object sender, EventArgs e)
+        {
+            return Task.FromResult(false);
         }
     }
 }

--- a/FRC-Extension/FRC-Extension.csproj
+++ b/FRC-Extension/FRC-Extension.csproj
@@ -204,6 +204,7 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="SimulatorWizards\MainProjectSearchWizard.cs" />
+    <Compile Include="ThreadHelperExtensions.cs" />
     <Compile Include="WPILibFolder\WPILibFolderStructure.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/FRC-Extension/MonoCode/MonoDeploy.cs
+++ b/FRC-Extension/MonoCode/MonoDeploy.cs
@@ -17,83 +17,82 @@ namespace RobotDotNet.FRC_Extension.MonoCode
             m_monoFile = monoFile;
         }
 
-        internal async Task DeployMono()
+        internal async Task DeployMonoAsync()
         {
             var writer = OutputWriter.Instance;
-            writer.Clear();
+            await writer.ClearAsync().ConfigureAwait(false);
 
             //Connect to RoboRIO
-            writer.WriteLine("Attempting to Connect to RoboRIO");
+            await writer.WriteLineAsync("Attempting to Connect to RoboRIO").ConfigureAwait(false);
 
-            Task<bool> rioConnectionTask = m_deployManager.StartConnectionTask(m_teamNumber);
+            Task<bool> rioConnectionTask = m_deployManager.StartConnectionTaskAsync(m_teamNumber);
             Task delayTask = Task.Delay(10000);
 
-
-            bool success = await m_monoFile.UnzipMonoFile();
+            bool success = await m_monoFile.UnzipMonoFileAsync().ConfigureAwait(false);
 
             if (!success) return;
 
             //Successfully extracted files.
 
-            writer.WriteLine("Waiting for Connection to Finish");
-            if (await Task.WhenAny(rioConnectionTask, delayTask) == rioConnectionTask)
+            await writer.WriteLineAsync("Waiting for Connection to Finish").ConfigureAwait(false);
+            if (await Task.WhenAny(rioConnectionTask, delayTask).ConfigureAwait(false) == rioConnectionTask)
             {
                 //Completed
                 if (rioConnectionTask.Result)
                 {
-                    writer.WriteLine("Successfully Connected to RoboRIO");
+                    await writer.WriteLineAsync("Successfully Connected to RoboRIO").ConfigureAwait(false);
 
                     List<string> deployFiles = m_monoFile.GetUnzippedFileList();
 
-                    writer.WriteLine("Creating Opkg Directory");
+                    await writer.WriteLineAsync("Creating Opkg Directory").ConfigureAwait(false);
 
-                    await RoboRIOConnection.RunCommand($"mkdir -p {DeployProperties.RoboRioOpgkLocation}", ConnectionUser.Admin);
+                    await RoboRIOConnection.RunCommandAsync($"mkdir -p {DeployProperties.RoboRioOpgkLocation}", ConnectionUser.Admin).ConfigureAwait(false);
 
-                    writer.WriteLine("Deploying Mono Files");
+                    await writer.WriteLineAsync("Deploying Mono Files").ConfigureAwait(false);
 
-                    success = await RoboRIOConnection.DeployFiles(deployFiles, DeployProperties.RoboRioOpgkLocation, ConnectionUser.Admin);
+                    success = await RoboRIOConnection.DeployFiles(deployFiles, DeployProperties.RoboRioOpgkLocation, ConnectionUser.Admin).ConfigureAwait(false);
 
                     if (!success)
                     {
                         return;
                     }
 
-                    writer.WriteLine("Installing Mono");
+                    await writer.WriteLineAsync("Installing Mono").ConfigureAwait(false);
 
-                    var monoRet = await RoboRIOConnection.RunCommand(DeployProperties.OpkgInstallCommand, ConnectionUser.Admin);
+                    var monoRet = await RoboRIOConnection.RunCommandAsync(DeployProperties.OpkgInstallCommand, ConnectionUser.Admin).ConfigureAwait(false);
 
                     //Check for success.
-                    bool monoSuccess = await m_deployManager.CheckMonoInstall();
+                    bool monoSuccess = await m_deployManager.CheckMonoInstallAsync().ConfigureAwait(false);
 
                     if (monoSuccess)
                     {
-                        writer.WriteLine("Mono Installed Successfully");
+                        await writer.WriteLineAsync("Mono Installed Successfully").ConfigureAwait(false);
                     }
                     else
                     {
-                        writer.WriteLine("Mono not installed successfully. Please try again.");
+                        await writer.WriteLineAsync("Mono not installed successfully. Please try again.").ConfigureAwait(false);
                     }
 
-                    writer.WriteLine("Cleaning up installation");
+                    await writer.WriteLineAsync("Cleaning up installation").ConfigureAwait(false);
                     // Set allow realtime on Mono instance
                     await
-                        RoboRIOConnection.RunCommand("setcap cap_sys_nice=pe /usr/bin/mono-sgen", ConnectionUser.Admin);
+                        RoboRIOConnection.RunCommandAsync("setcap cap_sys_nice=pe /usr/bin/mono-sgen", ConnectionUser.Admin).ConfigureAwait(false);
 
                     //Removing ipk files from the RoboRIO
-                    await RoboRIOConnection.RunCommand($"rm -rf {DeployProperties.RoboRioOpgkLocation}", ConnectionUser.Admin);
+                    await RoboRIOConnection.RunCommandAsync($"rm -rf {DeployProperties.RoboRioOpgkLocation}", ConnectionUser.Admin).ConfigureAwait(false);
 
-                    writer.WriteLine("Done. You may now deploy code to your robot.");
+                    await writer.WriteLineAsync("Done. You may now deploy code to your robot.").ConfigureAwait(false);
                 }
                 else
                 {
                     //Did not successfully connect
-                    writer.WriteLine("Failed to Connect to RoboRIO. Exiting.");
+                    await writer.WriteLineAsync("Failed to Connect to RoboRIO. Exiting.").ConfigureAwait(false);
                 }
             }
             else
             {
                 //Timedout
-                writer.WriteLine("RoboRIO connection timedout. Exiting.");
+                await writer.WriteLineAsync("RoboRIO connection timedout. Exiting.").ConfigureAwait(false);
             }
         }
     }

--- a/FRC-Extension/MonoCode/MonoFile.cs
+++ b/FRC-Extension/MonoCode/MonoFile.cs
@@ -82,7 +82,7 @@ namespace RobotDotNet.FRC_Extension.MonoCode
             return fileSum != null && fileSum.Equals(DeployProperties.MonoMd5);
         }
 
-        public async Task DownloadMono(IProgress<int> progress = null)
+        public async Task DownloadMonoAsync(IProgress<int> progress = null)
         {
             string target = DeployProperties.MonoUrl + DeployProperties.MonoVersion;
 
@@ -95,22 +95,22 @@ namespace RobotDotNet.FRC_Extension.MonoCode
                     {
                         progress?.Report(e.ProgressPercentage);
                     };
-                    await client.DownloadFileTaskAsync(new Uri(target), FileName);
+                    await client.DownloadFileTaskAsync(new Uri(target), FileName).ConfigureAwait(false);
                 }
             }
             catch (Exception)
             {
                 var writer = OutputWriter.Instance;
-                writer.WriteLine($"Could not download file: {DeployProperties.MonoVersion}");
+                await writer.WriteLineAsync($"Could not download file: {DeployProperties.MonoVersion}").ConfigureAwait(false);
             }
         }
 
         public List<string> GetUnzippedFileList()
         {
             return Directory.GetFiles(m_extractPath).ToList();
-        } 
+        }
 
-        public async Task<bool> UnzipMonoFile()
+        public async Task<bool> UnzipMonoFileAsync()
         {
             CleanupMonoFile();
 
@@ -120,7 +120,7 @@ namespace RobotDotNet.FRC_Extension.MonoCode
 
             try
             {
-                await Task.Run(() => ZipFile.ExtractToDirectory(FileName, m_extractPath));
+                await Task.Run(() => ZipFile.ExtractToDirectory(FileName, m_extractPath)).ConfigureAwait(false);
                 return true;
             }
             catch (IOException)

--- a/FRC-Extension/OutputWriter.cs
+++ b/FRC-Extension/OutputWriter.cs
@@ -3,6 +3,7 @@ using EnvDTE;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
 
 namespace RobotDotNet.FRC_Extension
 {
@@ -23,7 +24,6 @@ namespace RobotDotNet.FRC_Extension
 
         private OutputWriter()
         {
-
         }
 
         private void Initialize()
@@ -52,21 +52,20 @@ namespace RobotDotNet.FRC_Extension
                 return;
 
             m_initialized = true;
-
-
-
         }
 
-        public void Clear()
+        public async Task ClearAsync()
         {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             if (!m_initialized)
                 Initialize();
             if (!m_initialized) return;
             m_outputPane.Clear();
         }
 
-        public void Write(string value)
+        public async Task WriteAsync(string value)
         {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             if (!m_initialized)
                 Initialize();
             if (!m_initialized) return;
@@ -75,18 +74,19 @@ namespace RobotDotNet.FRC_Extension
             m_outputPane.Activate();
         }
 
-        public void Write(int value)
+        public Task WriteAsync(int value)
         {
-            Write(value.ToString());
+            return WriteAsync(value.ToString());
         }
 
-        public void Write(double value)
+        public Task WriteAsync(double value)
         {
-            Write(value.ToString());
+            return WriteAsync(value.ToString());
         }
 
-        public void WriteLine(string value)
+        public async Task WriteLineAsync(string value)
         {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             if (!m_initialized)
                 Initialize();
             if (!m_initialized) return;
@@ -95,20 +95,21 @@ namespace RobotDotNet.FRC_Extension
             m_outputPane.Activate();
         }
 
-        public void WriteLine(int value)
+        public Task WriteLineAsync(int value)
         {
-            WriteLine(value.ToString());
+            return WriteLineAsync(value.ToString());
         }
 
-        public void WriteLine(double value)
+        public Task WriteLineAsync(double value)
         {
-            WriteLine(value.ToString());
+            return WriteLineAsync(value.ToString());
         }
 
         private uint m_cookie;
         private string m_progressLabel;
 
-        public string ProgressBarLabel {
+        public string ProgressBarLabel
+        {
             get { return m_progressLabel; }
             set
             {

--- a/FRC-Extension/RoboRIOCode/DeployManager.cs
+++ b/FRC-Extension/RoboRIOCode/DeployManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
@@ -9,7 +8,6 @@ using System.Threading.Tasks;
 using System.Xml;
 using EnvDTE;
 using EnvDTE80;
-using RobotDotNet.FRC_Extension.MonoCode;
 using RobotDotNet.FRC_Extension.SettingsPages;
 
 namespace RobotDotNet.FRC_Extension.RoboRIOCode
@@ -26,123 +24,123 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
             m_dte = dte;
         }
 
-        
+
         //Uploads code to the robot and then runs it.
-        public async Task<bool> DeployCode(string teamNumber, bool debug, Project robotProject)
+        public async Task<bool> DeployCodeAsync(string teamNumber, bool debug, Project robotProject)
         {
 
             var writer = OutputWriter.Instance;
 
             if (robotProject == null)
             {
-                writer.WriteLine("Robot Project not valid. Contact RobotDotNet for support.");
+                await writer.WriteLineAsync("Robot Project not valid. Contact RobotDotNet for support.").ConfigureAwait(false);
                 return false;
             }
 
             //Connect to Robot Async
-            OutputWriter.Instance.WriteLine("Attempting to Connect to RoboRIO");
-            Task<bool> rioConnectionTask = StartConnectionTask(teamNumber);
+            await OutputWriter.Instance.WriteLineAsync("Attempting to Connect to RoboRIO").ConfigureAwait(false);
+            Task<bool> rioConnectionTask = StartConnectionTaskAsync(teamNumber);
             Task delayTask = Task.Delay(10000);
 
-            CodeReturnStruct codeReturn = await BuildAndPrepareCode(debug, robotProject);
+            CodeReturnStruct codeReturn = await BuildAndPrepareCodeAsync(debug, robotProject).ConfigureAwait(false);
 
             if (codeReturn == null) return false;
 
-            writer.WriteLine("Waiting for Connection to Finish");
-            if (await Task.WhenAny(rioConnectionTask, delayTask) == rioConnectionTask)
+            await writer.WriteLineAsync("Waiting for Connection to Finish").ConfigureAwait(false);
+            if (await Task.WhenAny(rioConnectionTask, delayTask).ConfigureAwait(false) == rioConnectionTask)
             {
                 //Completed on time
                 if (rioConnectionTask.Result)
                 {
                     //Connected successfully
-                    OutputWriter.Instance.WriteLine("Successfully Connected to RoboRIO.");
+                    await OutputWriter.Instance.WriteLineAsync("Successfully Connected to RoboRIO.").ConfigureAwait(false);
 
-                    if (!await CheckMonoInstall())
+                    if (!await CheckMonoInstallAsync().ConfigureAwait(false))
                     {
                         //TODO: Make this error message better
-                        OutputWriter.Instance.WriteLine("Mono not properly installed. Please try reinstalling to Mono Runtime.");
+                        await OutputWriter.Instance.WriteLineAsync("Mono not properly installed. Please try reinstalling to Mono Runtime.").ConfigureAwait(false);
                         return false;
                     }
-                    OutputWriter.Instance.WriteLine("Mono correctly installed");
+                    await OutputWriter.Instance.WriteLineAsync("Mono correctly installed").ConfigureAwait(false);
 
-                    OutputWriter.Instance.WriteLine("Checking RoboRIO Image");
-                    if (!await CheckRoboRioImage())
+                    await OutputWriter.Instance.WriteLineAsync("Checking RoboRIO Image").ConfigureAwait(false);
+                    if (!await CheckRoboRioImageAsync().ConfigureAwait(false))
                     {
                         // Ignore image requirement on selected option
                         if (!SettingsProvider.ExtensionSettingsPage.IgnoreImageRequirements)
                         {
-                            OutputWriter.Instance.WriteLine(
+                            await OutputWriter.Instance.WriteLineAsync(
                                 "RoboRIO Image does not match plugin, allowed image versions: " +
-                                string.Join(", ", DeployProperties.RoboRioAllowedImages.ToArray()));
-                            OutputWriter.Instance.WriteLine(
-                                "Please follow FIRST's instructions on imaging your RoboRIO, and try again.");
+                                string.Join(", ", DeployProperties.RoboRioAllowedImages.ToArray())).ConfigureAwait(false);
+                            await OutputWriter.Instance.WriteLineAsync(
+                                "Please follow FIRST's instructions on imaging your RoboRIO, and try again.").ConfigureAwait(false);
                             return false;
                         }
                     }
-                    OutputWriter.Instance.WriteLine("RoboRIO Image Correct");
+                    await OutputWriter.Instance.WriteLineAsync("RoboRIO Image Correct").ConfigureAwait(false);
                     //Force making mono directory
-                    await CreateMonoDirectory();
+                    await CreateMonoDirectoryAsync().ConfigureAwait(false);
 
                     bool nativeDeploy =
                         await
-                            CachedFileHelper.CheckAndDeployNativeLibraries(DeployProperties.UserLibraryDir, "WPI_Native_Libraries",
-                                GetProjectPath(robotProject) + "wpinative" + Path.DirectorySeparatorChar,
-                                new List<string>());
+                            CachedFileHelper.CheckAndDeployNativeLibrariesAsync(DeployProperties.UserLibraryDir, "WPI_Native_Libraries",
+                                await GetProjectPathAsync(robotProject).ConfigureAwait(false) + "wpinative" + Path.DirectorySeparatorChar,
+                                new List<string>()).ConfigureAwait(false);
 
                     if (!nativeDeploy)
                     {
-                        OutputWriter.Instance.WriteLine("Failed to deploy native files.");
+                        await OutputWriter.Instance.WriteLineAsync("Failed to deploy native files.").ConfigureAwait(false);
                         return false;
                     }
 
                     //DeployAllFiles
-                    bool retVal = await DeployRobotFiles(codeReturn.RobotFiles);
+                    bool retVal = await DeployRobotFilesAsync(codeReturn.RobotFiles).ConfigureAwait(false);
                     if (!retVal)
                     {
-                        OutputWriter.Instance.WriteLine("File deploy failed.");
+                        await OutputWriter.Instance.WriteLineAsync("File deploy failed.").ConfigureAwait(false);
                         return false;
                     }
-                    OutputWriter.Instance.WriteLine("Successfully Deployed Files. Starting Code.");
-                    await StartRobotCode(codeReturn.RobotExe, debug, robotProject);
-                    OutputWriter.Instance.WriteLine("Successfully started robot code.");
+                    await OutputWriter.Instance.WriteLineAsync("Successfully Deployed Files. Starting Code.").ConfigureAwait(false);
+                    await StartRobotCodeAsync(codeReturn.RobotExe, debug, robotProject).ConfigureAwait(false);
+                    await OutputWriter.Instance.WriteLineAsync("Successfully started robot code.").ConfigureAwait(false);
                     return true;
                 }
                 else
                 {
                     //Failed to connect
-                    writer.WriteLine("Failed to Connect to RoboRIO. Exiting.");
+                    await writer.WriteLineAsync("Failed to Connect to RoboRIO. Exiting.").ConfigureAwait(false);
                     return false;
                 }
             }
             else
             {
                 //Timedout
-                writer.WriteLine("Failed to Connect to RoboRIO. Exiting.");
+                await writer.WriteLineAsync("Failed to Connect to RoboRIO. Exiting.").ConfigureAwait(false);
                 return false;
             }
         }
 
-        public async Task<bool> StartConnectionTask(string teamNumber)
+        public async Task<bool> StartConnectionTaskAsync(string teamNumber)
         {
-                ConnectionReturn connected = await RoboRIOConnection.CheckConnection(teamNumber);
-                if (connected != null)
-                {
-                    StringBuilder builder = new StringBuilder();
-                    builder.AppendLine("Connected to RoboRIO...");
-                    builder.AppendLine("Interface: " + connected.ConnectionType);
-                    builder.Append("IP Address: " + connected.ConnectionIp);
-                    OutputWriter.Instance.WriteLine(builder.ToString());
-                    m_connectionValues = connected;
-                    return true;
-                }
-                else
-                {
-                    OutputWriter.Instance.WriteLine("Failed to Connect to RoboRIO...");
-                    return false;
-                }
+            ConnectionReturn connected = await RoboRIOConnection.CheckConnectionAsync(teamNumber).ConfigureAwait(false);
+            if (connected != null)
+            {
+                StringBuilder builder = new StringBuilder();
+                builder.AppendLine("Connected to RoboRIO...");
+                builder.AppendLine("Interface: " + connected.ConnectionType);
+                builder.Append("IP Address: " + connected.ConnectionIp);
+                await OutputWriter.Instance.WriteLineAsync(builder.ToString()).ConfigureAwait(false);
+                m_connectionValues = connected;
+                return true;
+            }
+            else
+            {
+                await OutputWriter.Instance.WriteLineAsync("Failed to Connect to RoboRIO...").ConfigureAwait(false);
+                return false;
+            }
         }
 
-        public class CodeReturnStruct
+        private class CodeReturnStruct
         {
             public string RobotExe { get; }
             public List<string> RobotFiles { get; }
@@ -151,16 +149,15 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
             {
                 RobotExe = exe;
                 RobotFiles = files;
-            } 
+            }
         }
 
-
-        public async Task<CodeReturnStruct> BuildAndPrepareCode(bool debug, Project robotProject)
+        private async Task<CodeReturnStruct> BuildAndPrepareCodeAsync(bool debug, Project robotProject)
         {
-
             var writer = OutputWriter.Instance;
             //Build Code
-            writer.WriteLine("Building Robot Code");
+            await writer.WriteLineAsync("Building Robot Code").ConfigureAwait(false);
+            await ThreadHelperExtensions.SwitchToUiThread();
             var sb = (SolutionBuild2)m_dte.Solution.SolutionBuild;
             //Check if we are building for debug or release
             string configuration;
@@ -176,21 +173,18 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                 //Switch to release
                 sb.SolutionConfigurations.Item(configuration).Activate();
             }
-            await Task.Run(() => sb.BuildProject(configuration, robotProject.FullName, true));
-
-            
+            sb.BuildProject(configuration, robotProject.FullName, true);
 
             //If Build Succeded
             if (sb.LastBuildInfo == 0)
             {
-                writer.WriteLine("Successfully Built Robot Code");
+                await writer.WriteLineAsync("Successfully Built Robot Code").ConfigureAwait(false);
                 //string path = GetStartupAssemblyPath();
-                string path = GetAssemblyPath(robotProject);
+                string path = await GetAssemblyPathAsync(robotProject).ConfigureAwait(false);
                 string robotExe = Path.GetFileName(path);
                 string buildDir = Path.GetDirectoryName(path);
 
-                
-                writer.WriteLine("Parsing Robot Files");
+                await writer.WriteLineAsync("Parsing Robot Files").ConfigureAwait(false);
                 //While connecting, parse all of the output files.
                 List<string> files = new List<string>();
                 if (Directory.Exists(buildDir))
@@ -198,9 +192,9 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                     await Task.Run(() =>
                     {
                         files.AddRange(Directory.GetFiles(buildDir).Where(f => !DeployProperties.IgnoreFiles.Any(f.Contains)));
-                    });
+                    }).ConfigureAwait(false);
                 }
-                writer.WriteLine("Parsed All Files.");
+                await writer.WriteLineAsync("Parsed All Files.").ConfigureAwait(false);
 
                 bool foundAll = true;
 
@@ -211,7 +205,7 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                     {
                         //Did not find a required file.
                         foundAll = false;
-                        writer.WriteLine($"Cound not find requred file: {requiredFile}");
+                        await writer.WriteLineAsync($"Cound not find requred file: {requiredFile}").ConfigureAwait(false);
                     }
                 }
 
@@ -223,55 +217,56 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
 
                 if (foundAll)
                 {
-                    writer.WriteLine("Found all needed WPILib files.");
+                    await writer.WriteLineAsync("Found all needed WPILib files.").ConfigureAwait(false);
                     return new CodeReturnStruct(robotExe, files);
                 }
                 else
                 {
-                    writer.WriteLine("Did not find all needed files. Canceling Deploy");
-                    writer.WriteLine("Please make sure the WPILib is the newest version from NuGet.");
+                    await writer.WriteLineAsync("Did not find all needed files. Canceling Deploy").ConfigureAwait(false);
+                    await writer.WriteLineAsync("Please make sure the WPILib is the newest version from NuGet.").ConfigureAwait(false);
                     return null;
                 }
             }
             else
             {
-                writer.WriteLine("Code build failed. Canceling Deploy");
+                await writer.WriteLineAsync("Code build failed. Canceling Deploy").ConfigureAwait(false);
                 return null;
             }
         }
 
-        public string GetCommandLineArguments(Project robotProject)
+        public async Task<string> GetCommandLineArgumentsAsync(Project robotProject)
         {
             if (!SettingsProvider.TeamSettingsPage.ConsoleArgs)
             {
                 return "";
             }
 
+            await ThreadHelperExtensions.SwitchToUiThread();
             Configuration configuration = robotProject.ConfigurationManager.ActiveConfiguration;
 
-            return (string) configuration.Properties.Item("StartArguments").Value;
+            return (string)configuration.Properties.Item("StartArguments").Value;
         }
 
-        public async Task<bool> DeployRobotFiles(List<string> files)
+        public async Task<bool> DeployRobotFilesAsync(List<string> files)
         {
-            OutputWriter.Instance.WriteLine("Deploying robot files");
-            return await RoboRIOConnection.DeployFiles(files, DeployProperties.DeployDir, ConnectionUser.LvUser);
+            await OutputWriter.Instance.WriteLineAsync("Deploying robot files").ConfigureAwait(false);
+            return await RoboRIOConnection.DeployFiles(files, DeployProperties.DeployDir, ConnectionUser.LvUser).ConfigureAwait(false);
         }
 
-        public async Task CreateMonoDirectory()
+        public async Task CreateMonoDirectoryAsync()
         {
-            OutputWriter.Instance.WriteLine("Creating Mono Deploy Directory");
-            await RoboRIOConnection.RunCommand($"mkdir -p {DeployProperties.DeployDir}", ConnectionUser.LvUser);
+            await OutputWriter.Instance.WriteLineAsync("Creating Mono Deploy Directory").ConfigureAwait(false);
+            await RoboRIOConnection.RunCommandAsync($"mkdir -p {DeployProperties.DeployDir}", ConnectionUser.LvUser).ConfigureAwait(false);
         }
 
-        public async Task<bool> CheckMonoInstall()
+        public async Task<bool> CheckMonoInstallAsync()
         {
-            OutputWriter.Instance.WriteLine("Checking for Mono install");
-            var retVal =  await RoboRIOConnection.RunCommand($"test -e {DeployProperties.RoboRioMonoBin}", ConnectionUser.LvUser);
+            await OutputWriter.Instance.WriteLineAsync("Checking for Mono install").ConfigureAwait(false);
+            var retVal = await RoboRIOConnection.RunCommandAsync($"test -e {DeployProperties.RoboRioMonoBin}", ConnectionUser.LvUser).ConfigureAwait(false);
             return retVal.ExitStatus == 0;
         }
 
-        public async Task<bool> CheckRoboRioImage()
+        public async Task<bool> CheckRoboRioImageAsync()
         {
             using (WebClient wc = new WebClient())
             {
@@ -282,7 +277,7 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                         {"Function", "GetPropertiesOfItem"},
                         {"Plugins", "nisyscfg"},
                         {"Items", "system"}
-                    });
+                    }).ConfigureAwait(false);
 
                 var sstring = Encoding.Unicode.GetString(result);
 
@@ -302,13 +297,15 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
             }
         }
 
-        internal string GetProjectPath(Project vsProject)
+        internal async Task<string> GetProjectPathAsync(Project vsProject)
         {
+            await ThreadHelperExtensions.SwitchToUiThread();
             return vsProject.Properties.Item("FullPath").Value.ToString();
         }
 
-        internal string GetAssemblyPath(Project vsProject)
+        internal async Task<string> GetAssemblyPathAsync(Project vsProject)
         {
+            await ThreadHelperExtensions.SwitchToUiThread();
             string fullPath = vsProject.Properties.Item("FullPath").Value.ToString();
             string outputPath =
                 vsProject.ConfigurationManager.ActiveConfiguration.Properties.Item("OutputPath").Value.ToString();
@@ -318,14 +315,14 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
             return assemblyPath;
         }
 
-        public async Task StartRobotCode(string robotName, bool debug, Project robotProject)
+        public async Task StartRobotCodeAsync(string robotName, bool debug, Project robotProject)
         {
             //TODO: Make debug work. Forcing debug to false for now so code always runs properly.
             debug = false;
 
             if (SettingsProvider.TeamSettingsPage.Netconsole)
             {
-                await StartNetConsole();
+                await StartNetConsoleAsync().ConfigureAwait(false);
             }
             string deployedCmd;
             string deployedCmdFrame;
@@ -340,10 +337,10 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                 deployedCmdFrame = DeployProperties.RobotCommandFileName;
             }
 
-            string args = GetCommandLineArguments(robotProject);
+            string args = await GetCommandLineArgumentsAsync(robotProject).ConfigureAwait(false);
 
             //Kill the currently running robot program
-            await RoboRIOConnection.RunCommand(DeployProperties.KillOnlyCommand, ConnectionUser.LvUser);
+            await RoboRIOConnection.RunCommandAsync(DeployProperties.KillOnlyCommand, ConnectionUser.LvUser).ConfigureAwait(false);
 
             //Combining all other commands, since they should be safe running together.
             List<string> commands = new List<string>();
@@ -358,57 +355,54 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
             //Add all commands to restart
             commands.AddRange(DeployProperties.DeployKillCommand);
             //run all commands
-            await RoboRIOConnection.RunCommands(commands.ToArray(), ConnectionUser.LvUser);
+            await RoboRIOConnection.RunCommandsAsync(commands.ToArray(), ConnectionUser.LvUser).ConfigureAwait(false);
 
             //Run sync so files are written to disk.
-            await RoboRIOConnection.RunCommand("sync", ConnectionUser.LvUser);
+            await RoboRIOConnection.RunCommandAsync("sync", ConnectionUser.LvUser).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Starts NetConsole
         /// </summary>
-        public static async Task StartNetConsole()
+        public static async Task StartNetConsoleAsync()
         {
-            await Task.Run(() =>
+            //If NetConsole is already running, don't do anything
+            if (System.Diagnostics.Process.GetProcessesByName("NetConsole.exe").Length == 0)
             {
-                //If NetConsole is already running, don't do anything
-                if (System.Diagnostics.Process.GetProcessesByName("NetConsole.exe").Length == 0)
+                //Else Start Netconsole
+                //There are 2 locations it could be. Check both.
+                await OutputWriter.Instance.WriteLineAsync("Starting netconsole").ConfigureAwait(false);
+                if (File.Exists(@"C:\Program Files (x86)\NetConsole for cRIO\NetConsole.exe"))
                 {
-                    //Else Start Netconsole
-                    //There are 2 locations it could be. Check both.
-                    OutputWriter.Instance.WriteLine("Starting netconsole");
-                    if (File.Exists(@"C:\Program Files (x86)\NetConsole for cRIO\NetConsole.exe"))
+                    try
                     {
-                        try
-                        {
-                            System.Diagnostics.Process.Start(
-                                @"C:\Program Files (x86)\NetConsole for cRIO\NetConsole.exe");
-                            OutputWriter.Instance.WriteLine("netconsole started.");
-                            return;
-                        }
-                        catch
-                        {
-                            OutputWriter.Instance.WriteLine("Could not start netconsole");
-                            return;
-                        }
+                        System.Diagnostics.Process.Start(
+                            @"C:\Program Files (x86)\NetConsole for cRIO\NetConsole.exe");
+                        await OutputWriter.Instance.WriteLineAsync("netconsole started.").ConfigureAwait(false);
+                        return;
                     }
-                    if (File.Exists(@"C:\Program Files\NetConsole for cRIO\NetConsole.exe"))
+                    catch
                     {
-                        try
-                        {
-                            System.Diagnostics.Process.Start(@"C:\Program Files\NetConsole for cRIO\NetConsole.exe");
-                            OutputWriter.Instance.WriteLine("netconsole started.");
-                            return;
-                        }
-                        catch
-                        {
-                            OutputWriter.Instance.WriteLine("Could not start netconsole");
-                            return;
-                        }
+                        await OutputWriter.Instance.WriteLineAsync("Could not start netconsole").ConfigureAwait(false);
+                        return;
                     }
-                    OutputWriter.Instance.WriteLine("Could not start netconsole");
                 }
-            });
+                if (File.Exists(@"C:\Program Files\NetConsole for cRIO\NetConsole.exe"))
+                {
+                    try
+                    {
+                        System.Diagnostics.Process.Start(@"C:\Program Files\NetConsole for cRIO\NetConsole.exe");
+                        await OutputWriter.Instance.WriteLineAsync("netconsole started.").ConfigureAwait(false);
+                        return;
+                    }
+                    catch
+                    {
+                        await OutputWriter.Instance.WriteLineAsync("Could not start netconsole").ConfigureAwait(false);
+                        return;
+                    }
+                }
+                await OutputWriter.Instance.WriteLineAsync("Could not start netconsole").ConfigureAwait(false);
+            }
         }
     }
 }

--- a/FRC-Extension/RoboRIOCode/RoboRIOConnection.cs
+++ b/FRC-Extension/RoboRIOCode/RoboRIOConnection.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Shell;
 using Renci.SshNet;
@@ -16,6 +19,7 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
     {
         USB,
         MDNS,
+        LAN,
         IP,
         None
     }
@@ -26,73 +30,189 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
         LvUser
     }
 
-    public class ConnectionReturn
+    public class ConnectionStatus
     {
         public ConnectionType ConnectionType { get; private set; }
-        public string ConnectionIp { get; private set; }
-        public bool Success { get; private set; }
+        public IPAddress ConnectionIp { get; private set; }
 
-        public ConnectionReturn(ConnectionType type, string ip, bool success)
+        public ConnectionStatus(ConnectionType type, IPAddress ip)
         {
             ConnectionType = type;
             ConnectionIp = ip;
-            Success = success;
         }
     }
 
 
-    public static class RoboRIOConnection
+
+    public class RoboRioConnection : IDisposable
     {
-
-
         public const string RoboRioMdnsFormatString = "roborio-{0}-FRC.local";
+        public const string RoboRioLanFormatString = "roborio-{0}-FRC.lan";
         public const string RoboRioUSBIp = "172.22.11.2";
         public const string RoboRioIpFormatString = "10.{0}.{1}.2";
 
-        private static ConnectionInfo s_adminConnectionInfo;
-        private static ConnectionInfo s_lvUserConnectionInfo;
+        private int m_teamNumber;
+        private IPAddress m_remoteIp;
+        private TimeSpan m_sshTimeout;
+        private ConnectionType m_connectionType = ConnectionType.None;
 
-        public static ConnectionInfo AdminConnectionInfo => s_adminConnectionInfo;
-        public static ConnectionInfo LvUserConnectionInfo => s_lvUserConnectionInfo;
+        private ConnectionInfo m_adminConnectionInfo;
+        private ConnectionInfo m_lvUserConnectionInfo;
 
-        public static async Task<ConnectionReturn> CheckConnectionAsync(string teamNumberS)
+        private SshClient m_sshAdminClient;
+        private SshClient m_sshUserClient;
+        private ScpClient m_scpUserClient;
+        private ScpClient m_scpAdminClient;
+
+        public IPAddress IPAddress => m_remoteIp;
+
+        public ConnectionStatus ConnectionStatus
         {
-            return await CheckConnectionAsync(teamNumberS, TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+            get
+            {
+                if (m_remoteIp == null)
+                {
+                    return null;
+                }
+                return new ConnectionStatus(m_connectionType, m_remoteIp);
+            }
         }
 
-        public static async Task<ConnectionReturn> CheckConnectionAsync(string teamNumberS, TimeSpan timeout)
+        public bool Connected => m_remoteIp != null;
+
+
+        public RoboRioConnection(int teamNumber, TimeSpan sshTimeout)
+        {
+            m_teamNumber = teamNumber;
+            m_sshTimeout = sshTimeout;
+        }
+
+        public void Dispose()
+        {
+            m_scpAdminClient?.Dispose();
+            m_sshUserClient?.Dispose();
+            m_scpUserClient?.Dispose();
+            m_scpAdminClient?.Dispose();
+        }
+
+        public static async Task<RoboRioConnection> StartConnectionTaskAsync(string teamNumberS)
         {
             int teamNumber;
             int.TryParse(teamNumberS, out teamNumber);
-
-
             if (teamNumber < 0)
             {
                 teamNumber = 0;
             }
-            string roboRioMDNS = string.Format(RoboRioMdnsFormatString, teamNumber);
-            string roboRIOIP = string.Format(RoboRioIpFormatString, teamNumber / 100, teamNumber % 100);
-
-            if (await GetWorkingConnectionInfoAsync(roboRioMDNS, timeout).ConfigureAwait(false))
+            var m_roboRioConnection = new RoboRioConnection(teamNumber, TimeSpan.FromSeconds(2));
+            bool connected = await m_roboRioConnection.GetConnectionAsync().ConfigureAwait(false);
+            if (connected)
             {
-                return new ConnectionReturn(ConnectionType.MDNS, roboRioMDNS, true);
+                StringBuilder builder = new StringBuilder();
+                ConnectionStatus status = m_roboRioConnection.ConnectionStatus;
+                builder.AppendLine("Connected to RoboRIO...");
+                builder.AppendLine("Interface: " + status.ConnectionType);
+                builder.Append("IP Address: " + status.ConnectionIp.ToString());
+                await OutputWriter.Instance.WriteLineAsync(builder.ToString()).ConfigureAwait(false);
             }
-            else if (await GetWorkingConnectionInfoAsync(RoboRioUSBIp, timeout).ConfigureAwait(false))
+            else
             {
-                return new ConnectionReturn(ConnectionType.USB, RoboRioUSBIp, true);
+                await OutputWriter.Instance.WriteLineAsync("Failed to Connect to RoboRIO...").ConfigureAwait(false);
             }
-            else if (await GetWorkingConnectionInfoAsync(roboRIOIP, timeout).ConfigureAwait(false))
-            {
-                return new ConnectionReturn(ConnectionType.IP, roboRIOIP, true);
-            }
-            s_lvUserConnectionInfo = null;
-            s_adminConnectionInfo = null;
-            return null;
+            return m_roboRioConnection;
         }
 
-        private static async Task<bool> GetWorkingConnectionInfoAsync(string ip, TimeSpan timeout)
+        public async Task<bool> GetConnectionAsync()
         {
+            if (m_teamNumber < 0)
+            {
+                m_teamNumber = 0;
+            }
+            string roboRioMDNS = string.Format(RoboRioMdnsFormatString, m_teamNumber);
+            string roboRioLan = string.Format(RoboRioLanFormatString, m_teamNumber);
+            string roboRIOIP = string.Format(RoboRioIpFormatString, m_teamNumber / 100, m_teamNumber % 100);
 
+            using (TcpClient usbClient = new TcpClient())
+            using (TcpClient mDnsClient = new TcpClient())
+            using (TcpClient lanClient = new TcpClient())
+            using (TcpClient ipClient = new TcpClient())
+            {
+
+                Task usb = usbClient.ConnectAsync(RoboRioUSBIp, 80);
+                Task mDns = mDnsClient.ConnectAsync(roboRioMDNS, 80);
+                Task lan = lanClient.ConnectAsync(roboRioLan, 80);
+                Task ip = ipClient.ConnectAsync(roboRIOIP, 80);
+                Task delayTask = Task.Delay(10000);
+
+                // http://stackoverflow.com/questions/24441474/await-list-of-async-predicates-but-drop-out-on-first-false
+                List<Task> tasks = new List<Task>()
+                {
+                    usb, mDns, lan, ip, delayTask
+                };
+
+                while (tasks.Count != 0)
+                {
+                    var finished = await Task.WhenAny(tasks);
+
+                    if (finished == delayTask)
+                    {
+                        return false;
+                    }
+                    else if (finished.IsCompleted && !finished.IsFaulted && !finished.IsCanceled)
+                    {
+                        // A task finished, find our host
+                        TcpClient foundHost = null;
+                        if (finished == usb)
+                        {
+                            foundHost = usbClient;
+                            m_connectionType = ConnectionType.USB;
+                        }
+                        else if (finished == mDns)
+                        {
+                            foundHost = mDnsClient;
+                            m_connectionType = ConnectionType.MDNS;
+                        }
+                        else if (finished == lan)
+                        {
+                            foundHost = lanClient;
+                            m_connectionType = ConnectionType.LAN;
+                        }
+                        else if (finished == ip)
+                        {
+                            foundHost = ipClient;
+                            m_connectionType = ConnectionType.IP;
+                        }
+                        else
+                        {
+                            // Error
+                            return false;
+                        }
+
+                        var ep = foundHost.Client.RemoteEndPoint;
+                        var ipEp = ep as IPEndPoint;
+                        if (ipEp == null)
+                        {
+                            // Continue, we cannot use this one
+
+                        }
+                        else
+                        {
+                            bool finishedConnect = await OnConnectionFound(ipEp.Address);
+                            if (finishedConnect)
+                            {
+                                m_remoteIp = ipEp.Address;
+                            }
+                            return finishedConnect;
+                        }
+                    }
+                    tasks.Remove(finished);
+                }
+                // If we have ever gotten here, return false
+                return false;
+            }
+        }
+
+        private async Task<bool> OnConnectionFound(IPAddress ip)
+        {
             //User auth method
             KeyboardInteractiveAuthenticationMethod authMethod = new KeyboardInteractiveAuthenticationMethod("lvuser");
             PasswordAuthenticationMethod pauth = new PasswordAuthenticationMethod("lvuser", "");
@@ -123,118 +243,139 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                 }
             };
 
-            s_lvUserConnectionInfo = new ConnectionInfo(ip, "lvuser", pauth, authMethod) { Timeout = timeout };
+            m_lvUserConnectionInfo = new ConnectionInfo(ip.ToString(), "lvuser", pauth, authMethod) { Timeout = m_sshTimeout };
 
 
-            s_adminConnectionInfo = new ConnectionInfo(ip, "admin", pauthAdmin, authMethodAdmin) { Timeout = timeout };
-            using (SshClient zeroConfClient = new SshClient(s_lvUserConnectionInfo))
+            m_adminConnectionInfo = new ConnectionInfo(ip.ToString(), "admin", pauthAdmin, authMethodAdmin) { Timeout = m_sshTimeout };
+
+            try
             {
-                try
-                {
-                    await Task.Run(() => zeroConfClient.Connect()).ConfigureAwait(false);
-                    return true;
-                }
-                catch (SocketException)
-                {
-                    return false;
-                }
-                catch (SshOperationTimeoutException)
-                {
-                    return false;
-                }
+                m_sshUserClient = new SshClient(m_lvUserConnectionInfo);
+                await Task.Run(() => m_sshUserClient.Connect()).ConfigureAwait(false);
             }
+            catch (SocketException e)
+            {
+                return false;
+            }
+            catch (SshOperationTimeoutException e )
+            {
+                return false;
+            }
+
+            try
+            {
+                m_scpUserClient = new ScpClient(m_lvUserConnectionInfo);
+                await Task.Run(() => m_scpUserClient.Connect()).ConfigureAwait(false);
+            }
+            catch (SocketException e)
+            {
+                return false;
+            }
+            catch (SshOperationTimeoutException e)
+            {
+                return false;
+            }
+
+            try
+            {
+                m_sshAdminClient = new SshClient(m_adminConnectionInfo);
+                await Task.Run(() => m_sshAdminClient.Connect()).ConfigureAwait(false);
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+            catch (SshOperationTimeoutException)
+            {
+                return false;
+            }
+
+            try
+            {
+                m_scpAdminClient = new ScpClient(m_adminConnectionInfo);
+                await Task.Run(() => m_scpAdminClient.Connect()).ConfigureAwait(false);
+            }
+            catch (SocketException)
+            {
+                return false;
+            }
+            catch (SshOperationTimeoutException)
+            {
+                return false;
+            }
+
+            return true;
         }
 
-        public static async Task<Dictionary<string, SshCommand>> RunCommandsAsync(string[] commands, ConnectionUser user)
+        public async Task<Dictionary<string, SshCommand>> RunCommandsAsync(IList<string> commands,
+            ConnectionUser user)
         {
-            ConnectionInfo connectionInfo;
+            SshClient ssh;
             switch (user)
             {
                 case ConnectionUser.Admin:
-                    connectionInfo = s_adminConnectionInfo;
+                    ssh = m_sshAdminClient;
                     break;
                 case ConnectionUser.LvUser:
-                    connectionInfo = s_lvUserConnectionInfo;
+                    ssh = m_sshUserClient;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(user), user, null);
             }
 
             Dictionary<string, SshCommand> retCommands = new Dictionary<string, SshCommand>();
-            using (SshClient ssh = new SshClient(connectionInfo))
-            {
-                try
-                {
-                    await Task.Run(() => ssh.Connect()).ConfigureAwait(false);
-                }
-                catch (SshOperationTimeoutException)
-                {
-                    return null;
-                }
-                var settings = SettingsProvider.ExtensionSettingsPage;
-                bool verbose = settings.Verbose || settings.DebugMode;
-                foreach (string s in commands)
-                {
-                    if (verbose)
-                    {
-                        await OutputWriter.Instance.WriteLineAsync($"Running command: {s}").ConfigureAwait(false);
-                    }
-                    await Task.Run(() =>
-                    {
-                        var x = ssh.RunCommand(s);
 
-                        retCommands.Add(s, x);
-                    }).ConfigureAwait(false);
+            var settings = SettingsProvider.ExtensionSettingsPage;
+            bool verbose = settings.Verbose || settings.DebugMode;
+            foreach (string s in commands)
+            {
+                if (verbose)
+                {
+                    await OutputWriter.Instance.WriteLineAsync($"Running command: {s}").ConfigureAwait(false);
                 }
+                await Task.Run(() =>
+                {
+                    var x = ssh.RunCommand(s);
+
+                    retCommands.Add(s, x);
+                }).ConfigureAwait(false);
             }
             return retCommands;
         }
 
-        public static async Task<SshCommand> RunCommandAsync(string command, ConnectionUser user)
+        public async Task<SshCommand> RunCommandAsync(string command, ConnectionUser user)
         {
-            ConnectionInfo connectionInfo;
+            SshClient ssh;
             switch (user)
             {
                 case ConnectionUser.Admin:
-                    connectionInfo = s_adminConnectionInfo;
+                    ssh = m_sshAdminClient;
                     break;
                 case ConnectionUser.LvUser:
-                    connectionInfo = s_lvUserConnectionInfo;
+                    ssh = m_sshUserClient;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(user), user, null);
             }
-
-            using (SshClient ssh = new SshClient(connectionInfo))
+            var settings = SettingsProvider.ExtensionSettingsPage;
+            bool verbose = settings.Verbose || settings.DebugMode;
+            if (verbose)
             {
-                try
-                {
-                    await Task.Run(() => ssh.Connect()).ConfigureAwait(false);
-                }
-                catch (SshOperationTimeoutException)
-                {
-                    return null;
-                }
-                var settings = SettingsProvider.ExtensionSettingsPage;
-                bool verbose = settings.Verbose || settings.DebugMode;
-                if (verbose)
-                {
-                    await OutputWriter.Instance.WriteLineAsync($"Running command: {command}").ConfigureAwait(false);
-                }
-                return await Task.Run(() => ssh.RunCommand(command)).ConfigureAwait(false);
+                await OutputWriter.Instance.WriteLineAsync($"Running command: {command}").ConfigureAwait(false);
             }
+            return await Task.Run(() => ssh.RunCommand(command)).ConfigureAwait(false);
         }
 
-        public static async Task<bool> ReceiveFileAsync(string remoteFile, Stream receiveStream, ConnectionUser user)
+        public async Task<bool> ReceiveFileAsync(string remoteFile, Stream receiveStream, ConnectionUser user)
         {
-            ConnectionInfo connectionInfo;
+            ScpClient scp;
             switch (user)
             {
                 case ConnectionUser.Admin:
-                    connectionInfo = s_adminConnectionInfo;
+                    scp = m_scpAdminClient;
                     break;
                 case ConnectionUser.LvUser:
-                    connectionInfo = s_lvUserConnectionInfo;
+                    scp = m_scpUserClient;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(user), user, null);
@@ -245,108 +386,72 @@ namespace RobotDotNet.FRC_Extension.RoboRIOCode
                 return false;
             }
 
-            if (connectionInfo == null) return false;
-            using (ScpClient scp = new ScpClient(connectionInfo))
+            var settings = SettingsProvider.ExtensionSettingsPage;
+            bool verbose = settings.Verbose || settings.DebugMode;
+            if (verbose)
             {
-                try
-                {
-                    await Task.Run(() => scp.Connect()).ConfigureAwait(false);
-                }
-                catch (SshOperationTimeoutException)
-                {
-                    return false;
-                }
-                var settings = SettingsProvider.ExtensionSettingsPage;
-                bool verbose = settings.Verbose || settings.DebugMode;
-                if (verbose)
-                {
-                    await OutputWriter.Instance.WriteLineAsync($"Receiving File: {remoteFile}").ConfigureAwait(false);
-                }
-                try
-                {
-                    await Task.Run(() => scp.Download(remoteFile, receiveStream)).ConfigureAwait(false);
-                }
-                catch (SshException)
-                {
-                    return false;
-                }
+                await OutputWriter.Instance.WriteLineAsync($"Receiving File: {remoteFile}").ConfigureAwait(false);
+            }
+            try
+            {
+                await Task.Run(() => scp.Download(remoteFile, receiveStream)).ConfigureAwait(false);
+            }
+            catch (SshException)
+            {
+                return false;
             }
             return true;
         }
 
-        public static async Task<bool> DeployFileAsync(Stream file, string deployLocation, ConnectionUser user)
+        public async Task<bool> DeployFileAsync(Stream file, string deployLocation, ConnectionUser user)
         {
-            ConnectionInfo connectionInfo;
+            ScpClient scp;
             switch (user)
             {
                 case ConnectionUser.Admin:
-                    connectionInfo = s_adminConnectionInfo;
+                    scp = m_scpAdminClient;
                     break;
                 case ConnectionUser.LvUser:
-                    connectionInfo = s_lvUserConnectionInfo;
+                    scp = m_scpUserClient;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(user), user, null);
             }
 
-            if (connectionInfo == null) return false;
-            using (ScpClient scp = new ScpClient(connectionInfo))
+            var settings = SettingsProvider.ExtensionSettingsPage;
+            bool verbose = settings.Verbose || settings.DebugMode;
+            if (verbose)
             {
-                try
-                {
-                    await Task.Run(() => scp.Connect()).ConfigureAwait(false);
-                }
-                catch (SshOperationTimeoutException)
-                {
-                    return false;
-                }
-                var settings = SettingsProvider.ExtensionSettingsPage;
-                bool verbose = settings.Verbose || settings.DebugMode;
-                if (verbose)
-                {
-                    await OutputWriter.Instance.WriteLineAsync($"Deploying File: {deployLocation}").ConfigureAwait(false);
-                }
-                await Task.Run(() => scp.Upload(file, deployLocation)).ConfigureAwait(false);
+                await OutputWriter.Instance.WriteLineAsync($"Deploying File: {deployLocation}").ConfigureAwait(false);
             }
+            await Task.Run(() => scp.Upload(file, deployLocation)).ConfigureAwait(false);
             return true;
         }
 
-        public static async Task<bool> DeployFiles(IEnumerable<string> files, string deployLocation, ConnectionUser user)
+        public async Task<bool> DeployFiles(IEnumerable<string> files, string deployLocation, ConnectionUser user)
         {
-            ConnectionInfo connectionInfo;
+            ScpClient scp;
             switch (user)
             {
                 case ConnectionUser.Admin:
-                    connectionInfo = s_adminConnectionInfo;
+                    scp = m_scpAdminClient;
                     break;
                 case ConnectionUser.LvUser:
-                    connectionInfo = s_lvUserConnectionInfo;
+                    scp = m_scpUserClient;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(user), user, null);
             }
 
-            if (connectionInfo == null) return false;
-            using (ScpClient scp = new ScpClient(connectionInfo))
+            var settings = SettingsProvider.ExtensionSettingsPage;
+            bool verbose = settings.Verbose || settings.DebugMode;
+            foreach (FileInfo fileInfo in from string s in files where File.Exists(s) select new FileInfo(s))
             {
-                try
+                if (verbose)
                 {
-                    await Task.Run(() => scp.Connect()).ConfigureAwait(false);
+                    await OutputWriter.Instance.WriteLineAsync($"Deploying File: {fileInfo.Name}").ConfigureAwait(false);
                 }
-                catch (SshOperationTimeoutException)
-                {
-                    return false;
-                }
-                var settings = SettingsProvider.ExtensionSettingsPage;
-                bool verbose = settings.Verbose || settings.DebugMode;
-                foreach (FileInfo fileInfo in from string s in files where File.Exists(s) select new FileInfo(s))
-                {
-                    if (verbose)
-                    {
-                        await OutputWriter.Instance.WriteLineAsync($"Deploying File: {fileInfo.Name}").ConfigureAwait(false);
-                    }
-                    await Task.Run(() => scp.Upload(fileInfo, deployLocation)).ConfigureAwait(false);
-                }
+                await Task.Run(() => scp.Upload(fileInfo, deployLocation)).ConfigureAwait(false);
             }
             return true;
         }

--- a/FRC-Extension/SimulatorWizards/MainProjectSearchWizard.cs
+++ b/FRC-Extension/SimulatorWizards/MainProjectSearchWizard.cs
@@ -23,6 +23,7 @@ namespace RobotDotNet.FRC_Extension.SimulatorWizards
         /// <param name="customParams"></param>
         public void RunStarted(object automationObject, Dictionary<string, string> replacementsDictionary, WizardRunKind runKind, object[] customParams)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
             var dte = automationObject as DTE;
             //Do nothing if we cannot access our automation object
             if (dte == null)
@@ -62,7 +63,7 @@ namespace RobotDotNet.FRC_Extension.SimulatorWizards
             }
             catch (Exception ex)
             {
-                OutputWriter.Instance.WriteLine(ex.StackTrace);
+                ThreadHelper.JoinableTaskFactory.Run(() => OutputWriter.Instance.WriteLineAsync(ex.StackTrace));
             }
         }
 
@@ -142,8 +143,8 @@ namespace RobotDotNet.FRC_Extension.SimulatorWizards
         public void ProjectFinishedGenerating(Project project)
         {
             var vsproject = project.Object as VSProject;
-            
-            
+
+
             if (vsproject != null && m_robotProject != null)
             {
                 vsproject.References.AddProject(m_robotProject);
@@ -158,7 +159,7 @@ namespace RobotDotNet.FRC_Extension.SimulatorWizards
 
         public void ProjectItemFinishedGenerating(ProjectItem projectItem)
         {
-            
+
         }
 
         public bool ShouldAddProjectItem(string filePath)
@@ -168,12 +169,12 @@ namespace RobotDotNet.FRC_Extension.SimulatorWizards
 
         public void BeforeOpeningFile(ProjectItem projectItem)
         {
-            
+
         }
 
         public void RunFinished()
         {
-            
+
         }
     }
 }

--- a/FRC-Extension/ThreadHelperExtensions.cs
+++ b/FRC-Extension/ThreadHelperExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.VisualStudio.Shell;
+using static Microsoft.VisualStudio.Threading.JoinableTaskFactory;
+
+namespace RobotDotNet.FRC_Extension
+{
+    internal static class ThreadHelperExtensions
+    {
+        public static MainThreadAwaitable SwitchToUiThread()
+        {
+            return ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+        }
+    }
+}


### PR DESCRIPTION
This is a major refactoring of everything async, making sure that all COM/UI interactions happen on the UI thread, and everything that does not need to use the UI thread doesn't. Basically, anything that either accesses a VS interface or casts a VS object to some other interface needs to occur on the UI thread. I've renamed async methods to use the ends with Async. There were a few other things I refactored, giving GetService a generic wrapper and making the output functions async.